### PR TITLE
added __truediv__, __div__ now is an alias for that

### DIFF
--- a/numscrypt/__init__.py
+++ b/numscrypt/__init__.py
@@ -469,7 +469,7 @@ class ndarray:
     def __rmul__ (self, scalar):    # scalar * array -> array.__rmul__ (scalar)
         return self.__mul__ (scalar)
         
-    def __div__ (self, other):
+    def __truediv__ (self, other):
         result = empty (self.shape, self.dtype)
         
         if type (other) == ndarray:
@@ -499,8 +499,15 @@ class ndarray:
                     
         return result
         
-    def __rdiv__ (self, scalar):    # scalar / array -> array.__rdiv__ (scalar)
+    def __rtruediv__ (self, scalar):    # scalar / array -> array.__rdiv__ (scalar)
         return self.__ns_inv__ () .__mul__ (scalar)
+
+    # prefer the python 3 __truediv__, but retain __div__ for compatibility
+    def __div__(self, other):
+        return self.__truediv__(other)
+
+    def __rdiv__(self, other):
+        return self.__rtruediv__(other)
         
     def __matmul__ (self, other):
         result = empty ((self.ns_nrows, other.ns_ncols), self.dtype)


### PR DESCRIPTION
Adding the `__truediv__` magic method, with `__div__` as an alias to that for backward compatibility and python3 standards